### PR TITLE
Display subtitles on mp4 videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Convert images to Unicode braille art for terminal display.
 - Encode JPEG, PNG, GIF, and BMP images as braille Unicode characters
 - Animated GIF support with proper frame timing and disposal methods
 - MP4 video playback with H.264 decoding (requires FFmpeg)
+- Embedded subtitle rendering for MP4 files (mov_text format)
 - MJPEG stream support for webcams and video feeds
 - Image adjustments: gamma, brightness, contrast, sharpening
 - Floyd-Steinberg dithering for grayscale preservation
@@ -67,7 +68,7 @@ curl -s https://example.com/image.jpg | dotmatrix
 # With options
 dotmatrix --invert --sharpen 50 image.png
 
-# Play MP4 video
+# Play MP4 video (subtitles are displayed if embedded)
 dotmatrix video.mp4
 
 # Play MP4 at specific framerate
@@ -130,6 +131,14 @@ Animated GIFs play directly in the terminal with proper timing:
 ![Animated GIF example](https://cloud.githubusercontent.com/assets/307864/16272242/0dc3b6d8-386b-11e6-9ea3-e55ee936ae54.gif)
 
 > **Note:** Terminal refresh rates vary. The default macOS Terminal.app works well; iTerm2 may have slower refresh rates.
+
+### MP4 Subtitles
+
+MP4 files with embedded subtitles (mov_text/tx3g format) will display subtitles overlaid at the bottom of the video. Subtitles are:
+
+- Automatically extracted and timed to video playback
+- Centered and wrapped to fit the terminal width
+- Rendered over the braille output while preserving surrounding pixels
 
 ## How It Works
 

--- a/mp4.go
+++ b/mp4.go
@@ -298,14 +298,39 @@ func (p *MP4Printer) Print(ctx context.Context, inputPath string, fps int) error
 				}
 			}
 
-			// Overlay subtitle on the last row of the braille output
+			// Overlay subtitle on the bottom rows of the braille output
 			imageWidthInChars := filteredImg.Bounds().Dx() / 2
 			currentPTS := frame.Pts()
 			activeSubtitle := findActiveSubtitle(subtitles, currentPTS)
 			if activeSubtitle != "" {
-				centered := centerText(activeSubtitle, imageWidthInChars)
-				// Move cursor up 1 line, to beginning, write subtitle, then back down
-				fmt.Fprintf(p.w, "\033[1A\r%s\033[1B\r", centered)
+				// Wrap and limit subtitle lines (max 3 lines, leave 1 line of braille visible at top minimum)
+				maxLines := 3
+				if rows-1 < maxLines {
+					maxLines = rows - 1
+				}
+				if maxLines < 1 {
+					maxLines = 1
+				}
+				lines := wrapText(activeSubtitle, imageWidthInChars, maxLines)
+				numLines := len(lines)
+
+				// Move cursor up to position subtitles at the bottom of the frame
+				// We go up (numLines) lines from the current position (which is after the last row)
+				fmt.Fprintf(p.w, "\033[%dA", numLines)
+
+				// Write each line centered
+				for i, line := range lines {
+					centered := centerText(line, imageWidthInChars)
+					fmt.Fprintf(p.w, "\r%s", centered)
+					if i < numLines-1 {
+						fmt.Fprint(p.w, "\n")
+					}
+				}
+
+				// Move cursor back down to the original position
+				// We're now on the last subtitle line (which is the last row of the frame)
+				// So we only need to move down 1 line to get back to where we started
+				fmt.Fprint(p.w, "\033[1B\r")
 			}
 
 			p.c.Reset(p.w, rows)
@@ -324,20 +349,90 @@ func findActiveSubtitle(subtitles []subtitle, pts int64) string {
 	return ""
 }
 
-// centerText centers text within the given width, truncating if necessary.
+// centerText centers text within the given width (assumes text already fits).
 func centerText(text string, width int) string {
-	text = strings.TrimSpace(text)
-
 	textLen := len([]rune(text))
 	if textLen >= width {
-		// Truncate to fit
-		runes := []rune(text)
-		if width > 3 {
-			return string(runes[:width-3]) + "..."
-		}
-		return string(runes[:width])
+		return text
 	}
-
 	padding := (width - textLen) / 2
 	return strings.Repeat(" ", padding) + text
+}
+
+// wrapText wraps text to fit within width, limiting to maxLines.
+// If text exceeds maxLines, the last line is truncated with ellipsis.
+func wrapText(text string, width, maxLines int) []string {
+	if width <= 0 || maxLines <= 0 {
+		return nil
+	}
+
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return nil
+	}
+
+	words := strings.Fields(text)
+	if len(words) == 0 {
+		return nil
+	}
+
+	var lines []string
+	var currentLine string
+
+	for _, word := range words {
+		wordRunes := []rune(word)
+
+		// If single word is longer than width, we need to handle it specially
+		if len(wordRunes) > width {
+			// Flush current line if not empty
+			if currentLine != "" {
+				lines = append(lines, currentLine)
+				currentLine = ""
+			}
+
+			// Break the long word across lines
+			for len(wordRunes) > 0 {
+				if len(lines) >= maxLines {
+					break
+				}
+				take := width
+				if take > len(wordRunes) {
+					take = len(wordRunes)
+				}
+				lines = append(lines, string(wordRunes[:take]))
+				wordRunes = wordRunes[take:]
+			}
+			continue
+		}
+
+		// Check if word fits on current line
+		if currentLine == "" {
+			currentLine = word
+		} else if len([]rune(currentLine))+1+len(wordRunes) <= width {
+			currentLine += " " + word
+		} else {
+			// Word doesn't fit, start new line
+			lines = append(lines, currentLine)
+			currentLine = word
+		}
+	}
+
+	// Don't forget the last line
+	if currentLine != "" {
+		lines = append(lines, currentLine)
+	}
+
+	// Limit to maxLines and add ellipsis if truncated
+	if len(lines) > maxLines {
+		lines = lines[:maxLines]
+		// Add ellipsis to last line
+		lastLine := []rune(lines[maxLines-1])
+		if len(lastLine)+3 <= width {
+			lines[maxLines-1] = string(lastLine) + "..."
+		} else if len(lastLine) > 3 {
+			lines[maxLines-1] = string(lastLine[:len(lastLine)-3]) + "..."
+		}
+	}
+
+	return lines
 }

--- a/mp4.go
+++ b/mp4.go
@@ -318,10 +318,16 @@ func (p *MP4Printer) Print(ctx context.Context, inputPath string, fps int) error
 				// We go up (numLines) lines from the current position (which is after the last row)
 				fmt.Fprintf(p.w, "\033[%dA", numLines)
 
-				// Write each line centered
+				// Write each line centered (preserving braille on left and right)
 				for i, line := range lines {
-					centered := centerText(line, imageWidthInChars)
-					fmt.Fprintf(p.w, "\r%s", centered)
+					// Calculate column position for centered text (1-indexed for ANSI)
+					lineLen := len([]rune(line))
+					startCol := (imageWidthInChars - lineLen) / 2
+					if startCol < 1 {
+						startCol = 1
+					}
+					// Move cursor to the start column and write text (preserves braille on sides)
+					fmt.Fprintf(p.w, "\033[%dG%s", startCol, line)
 					if i < numLines-1 {
 						fmt.Fprint(p.w, "\n")
 					}
@@ -347,16 +353,6 @@ func findActiveSubtitle(subtitles []subtitle, pts int64) string {
 		}
 	}
 	return ""
-}
-
-// centerText centers text within the given width (assumes text already fits).
-func centerText(text string, width int) string {
-	textLen := len([]rune(text))
-	if textLen >= width {
-		return text
-	}
-	padding := (width - textLen) / 2
-	return strings.Repeat(" ", padding) + text
 }
 
 // wrapText wraps text to fit within width, limiting to maxLines.

--- a/mp4.go
+++ b/mp4.go
@@ -2,13 +2,22 @@ package dotmatrix
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/asticode/go-astiav"
 )
+
+// subtitle holds a decoded subtitle with timing information.
+type subtitle struct {
+	startPTS int64
+	endPTS   int64
+	text     string
+}
 
 // MP4Printer prints MP4 video frames as braille characters.
 type MP4Printer struct {
@@ -60,14 +69,23 @@ func (p *MP4Printer) Print(ctx context.Context, inputPath string, fps int) error
 		return fmt.Errorf("mp4: finding stream info failed: %w", err)
 	}
 
-	// Find video stream
+	// Find video and subtitle streams
 	var videoStream *astiav.Stream
 	var videoStreamIdx int
+	var subtitleStream *astiav.Stream
+	var subtitleStreamIdx int
 	for _, s := range formatCtx.Streams() {
-		if s.CodecParameters().MediaType() == astiav.MediaTypeVideo {
-			videoStream = s
-			videoStreamIdx = s.Index()
-			break
+		switch s.CodecParameters().MediaType() {
+		case astiav.MediaTypeVideo:
+			if videoStream == nil {
+				videoStream = s
+				videoStreamIdx = s.Index()
+			}
+		case astiav.MediaTypeSubtitle:
+			if subtitleStream == nil {
+				subtitleStream = s
+				subtitleStreamIdx = s.Index()
+			}
 		}
 	}
 	if videoStream == nil {
@@ -95,6 +113,13 @@ func (p *MP4Printer) Print(ctx context.Context, inputPath string, fps int) error
 	// Open codec
 	if err := codecCtx.Open(codec, nil); err != nil {
 		return fmt.Errorf("mp4: opening codec failed: %w", err)
+	}
+
+	// Set up subtitle storage if subtitle stream exists
+	var subtitles []subtitle
+	var subtitleTimeBase astiav.Rational
+	if subtitleStream != nil {
+		subtitleTimeBase = subtitleStream.TimeBase()
 	}
 
 	// Create software scale context for converting to RGBA
@@ -130,6 +155,35 @@ func (p *MP4Printer) Print(ctx context.Context, inputPath string, fps int) error
 				return nil
 			}
 			return fmt.Errorf("mp4: reading frame failed: %w", err)
+		}
+
+		// Handle subtitle packets
+		if subtitleStream != nil && pkt.StreamIndex() == subtitleStreamIdx {
+			// Parse mov_text subtitle format (2-byte length prefix + UTF-8 text)
+			data := pkt.Data()
+			if len(data) >= 2 {
+				textLen := int(binary.BigEndian.Uint16(data[:2]))
+				if textLen > 0 && len(data) >= 2+textLen {
+					text := strings.TrimSpace(string(data[2 : 2+textLen]))
+					if text != "" {
+						// Convert subtitle PTS to video stream time base
+						pktPTS := pkt.Pts()
+						startPTS := pktPTS * int64(subtitleTimeBase.Num()) * int64(timeBase.Den()) / (int64(subtitleTimeBase.Den()) * int64(timeBase.Num()))
+						// Duration from packet, convert to video time base
+						pktDuration := pkt.Duration()
+						durationPTS := pktDuration * int64(subtitleTimeBase.Num()) * int64(timeBase.Den()) / (int64(subtitleTimeBase.Den()) * int64(timeBase.Num()))
+						endPTS := startPTS + durationPTS
+
+						subtitles = append(subtitles, subtitle{
+							startPTS: startPTS,
+							endPTS:   endPTS,
+							text:     text,
+						})
+					}
+				}
+			}
+			pkt.Unref()
+			continue
 		}
 
 		// Skip non-video packets
@@ -244,8 +298,46 @@ func (p *MP4Printer) Print(ctx context.Context, inputPath string, fps int) error
 				}
 			}
 
+			// Overlay subtitle on the last row of the braille output
+			imageWidthInChars := filteredImg.Bounds().Dx() / 2
+			currentPTS := frame.Pts()
+			activeSubtitle := findActiveSubtitle(subtitles, currentPTS)
+			if activeSubtitle != "" {
+				centered := centerText(activeSubtitle, imageWidthInChars)
+				// Move cursor up 1 line, to beginning, write subtitle, then back down
+				fmt.Fprintf(p.w, "\033[1A\r%s\033[1B\r", centered)
+			}
+
 			p.c.Reset(p.w, rows)
 			frame.Unref()
 		}
 	}
+}
+
+// findActiveSubtitle returns the subtitle text that should be displayed at the given PTS.
+func findActiveSubtitle(subtitles []subtitle, pts int64) string {
+	for _, s := range subtitles {
+		if pts >= s.startPTS && pts < s.endPTS {
+			return s.text
+		}
+	}
+	return ""
+}
+
+// centerText centers text within the given width, truncating if necessary.
+func centerText(text string, width int) string {
+	text = strings.TrimSpace(text)
+
+	textLen := len([]rune(text))
+	if textLen >= width {
+		// Truncate to fit
+		runes := []rune(text)
+		if width > 3 {
+			return string(runes[:width-3]) + "..."
+		}
+		return string(runes[:width])
+	}
+
+	padding := (width - textLen) / 2
+	return strings.Repeat(" ", padding) + text
 }


### PR DESCRIPTION
  Summary

  - Add subtitle extraction and rendering for MP4 files with embedded mov_text/tx3g subtitles
  - Subtitles are automatically displayed at the bottom of the video, overlaid on the braille output
  - Update README to document the new subtitle feature

  Details

  Subtitle Extraction:
  - Detects subtitle streams in MP4 files alongside video streams
  - Parses mov_text subtitle format (2-byte length prefix + UTF-8 text) directly from packet data
  - Converts subtitle timing from subtitle stream time base to video stream time base for accurate synchronization

  Subtitle Rendering:
  - Overlays subtitles on the bottom rows of the braille output (up to 3 lines max)
  - Text is word-wrapped to fit terminal width
  - Long text that exceeds available lines is truncated with ellipsis
  - Uses ANSI escape codes to position text, preserving braille pixels on left and right sides
  - No extra terminal rows required - subtitles are rendered within the existing frame

  Edge Cases Handled:
  - MP4 files without subtitles work exactly as before
  - Very small terminal heights limit subtitle lines while preserving at least 1 row of video
  - Long words that exceed terminal width are broken across lines

  Test plan

  - Test with MP4 that has embedded mov_text subtitles
  - Verify subtitles appear centered at correct times
  - Verify text wrapping works for long subtitles
  - Test with MP4 without subtitles (should work as before)
  - Verify no display artifacts or jumping when subtitle line count changes
