### PR TITLE
add releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            goos: linux
+            goarch: amd64
+            artifact: dotmatrix-linux-amd64
+          - os: macos-14
+            goos: darwin
+            goarch: arm64
+            artifact: dotmatrix-darwin-arm64
+          - os: macos-13
+            goos: darwin
+            goarch: amd64
+            artifact: dotmatrix-darwin-amd64
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - name: Install FFmpeg (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo add-apt-repository -y ppa:ubuntuhandbook1/ffmpeg7
+          sudo apt-get update
+          sudo apt-get install -y libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libswresample-dev libavdevice-dev libavfilter-dev
+
+      - name: Install FFmpeg (macOS)
+        if: runner.os == 'macOS'
+        run: brew install ffmpeg
+
+      - name: Get version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Build
+        env:
+          CGO_ENABLED: 1
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          go build -ldflags "-X main.version=${{ steps.version.outputs.VERSION }}" -o dotmatrix ./cmd/dotmatrix
+
+      - name: Create archive
+        run: |
+          tar -czvf ${{ matrix.artifact }}.tar.gz dotmatrix
+
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ matrix.artifact }}.tar.gz

--- a/cmd/dotmatrix/main.go
+++ b/cmd/dotmatrix/main.go
@@ -25,6 +25,10 @@ import (
 	"github.com/kevin-cantwell/dotmatrix"
 )
 
+// version is set at build time via ldflags:
+// go build -ldflags "-X main.version=1.0.0" ./cmd/dotmatrix
+var version = "dev"
+
 func main() {
 	defer func() {
 		if r := recover(); r != nil {
@@ -36,7 +40,7 @@ func main() {
 	app := &cli.App{
 		Name:            "dotmatrix",
 		Usage:           "Render images and video as Unicode braille art",
-		Version:         "0.2.0",
+		Version:         version,
 		UsageText:       "dotmatrix [options] [file|url]\ncat [file|url] | dotmatrix [options]",
 		HideHelpCommand: true,
 		Flags: []cli.Flag{

--- a/cmd/dotmatrix/main_test.go
+++ b/cmd/dotmatrix/main_test.go
@@ -834,9 +834,11 @@ func TestBrailleOutput_WhiteImage(t *testing.T) {
 }
 
 func TestCLI_Version(t *testing.T) {
+	// Test that the CLI framework correctly outputs version info.
+	// The actual version is injected at build time via ldflags.
 	app := &cli.App{
 		Name:    "dotmatrix",
-		Version: "0.1.0",
+		Version: "test-version",
 	}
 
 	var buf bytes.Buffer
@@ -848,7 +850,7 @@ func TestCLI_Version(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	if !strings.Contains(buf.String(), "0.1.0") {
+	if !strings.Contains(buf.String(), "test-version") {
 		t.Errorf("expected version in output, got: %s", buf.String())
 	}
 }


### PR DESCRIPTION
## Summary

  - Add automated GitHub Releases workflow triggered by `v*` tags
  - Inject version at build time via `-ldflags` instead of hardcoding
  - Build release binaries natively on each platform with FFmpeg support

## Test plan

  - [x] Verify version injection works: `go build -ldflags "-X main.version=test" ./cmd/dotmatrix`
  - [x] Run tests: `CGO_ENABLED=1 go test ./cmd/dotmatrix/... -v`
  - [ ] After merging, push tag `v0.2.0` and verify GitHub Actions creates release with binaries

## Release artifacts

  | Platform | Runner | Binary |
  |----------|--------|--------|
  | Linux (amd64) | ubuntu-24.04 | `dotmatrix-linux-amd64.tar.gz` |
  | macOS (arm64) | macos-14 | `dotmatrix-darwin-arm64.tar.gz` |
  | macOS (amd64) | macos-13 | `dotmatrix-darwin-amd64.tar.gz` |

  🤖 Generated with [Claude Code](https://claude.com/claude-code)
